### PR TITLE
added block chomping indicator to multiline yaml strings

### DIFF
--- a/data/weapons/boreus/BrutalityOfBoreus.yml
+++ b/data/weapons/boreus/BrutalityOfBoreus.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: BoreusFrostSprite
-    description: >
+    description: >-
       Using Ammo generates a Frost Sprite that cause your next attack to deal 50 bonus damage
       and minor frost damage. Max 4 Sprites. 

--- a/data/weapons/boreus/DestinyOfBoreus.yml
+++ b/data/weapons/boreus/DestinyOfBoreus.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: BoreusFrostSprite
-    description: >
+    description: >-
       Using Pips generates 2 Frost Sprites that cause your next attack to deal
       50 bonus damage and minor frost damage each. Max 4 Sprites.

--- a/data/weapons/boreus/OnusOfBoreus.yml
+++ b/data/weapons/boreus/OnusOfBoreus.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: BoreusFrostSprite
-    description: >
+    description: >-
        	Using a Special continually generates Frost Sprites that cause your next attack to deal
         50 bonus damage and minor frost damage. Max 4 Sprites.
 

--- a/data/weapons/boreus/RevolutionOfBoreus.yml
+++ b/data/weapons/boreus/RevolutionOfBoreus.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: BoreusFrostSprite
-    description: >
+    description: >-
       Using Ammo generates Frost Sprites (base on ammo quality) that cause your next attack to deal
       50 bonus damage and minor frost damage. Max 4 Sprites. 

--- a/data/weapons/boreus/TurmoilOfBoreus.yml
+++ b/data/weapons/boreus/TurmoilOfBoreus.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: BoreusFrostSprite
-    description: >
+    description: >-
       Charge Attacks generate Frost Sprites that cause your next attack to deal
       50 bonus damage and minor frost damage. Max 4 Sprites.

--- a/data/weapons/riftstalker/StalkersMercy.yml
+++ b/data/weapons/riftstalker/StalkersMercy.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: DamageShadowOrbs
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to generate a shadow orb that increases damage dealt by 2.5% for 5 seconds.
       If 5 or more orbs are present, the bonus doubles.

--- a/data/weapons/riftstalker/StalkersPrice.yml
+++ b/data/weapons/riftstalker/StalkersPrice.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: DamageShadowOrbs
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to generate a shadow orb that increases damage dealt by 2.5% for 5 seconds.
       If 5 or more orbs are present, the bonus doubles.

--- a/data/weapons/riftstalker/StalkersSpike.yml
+++ b/data/weapons/riftstalker/StalkersSpike.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: DamageShadowOrbs
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to generate a shadow orb that increases damage dealt by 2.5% for 5 seconds.
       If 5 or more orbs are present, the bonus doubles.

--- a/data/weapons/riftstalker/StalkersStrike.yml
+++ b/data/weapons/riftstalker/StalkersStrike.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: DamageShadowOrbs
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to generate a Shadow Orb that increases damage
       dealt by 2.5% for 5 seconds. If 5 or more Orbs are present, the bonus doubles.

--- a/data/weapons/riftstalker/StalkersTalons.yml
+++ b/data/weapons/riftstalker/StalkersTalons.yml
@@ -37,6 +37,6 @@ perks:
     to: 15
 unique_effects:
   - name: DamageShadowOrbs
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to generate a shadow orb that increases damage dealt by 2.5% for 5 seconds.
       If 5 or more orbs are present, the bonus doubles.

--- a/data/weapons/shrowd/TheHunger.yml
+++ b/data/weapons/shrowd/TheHunger.yml
@@ -25,6 +25,6 @@ power:
   15: 550
 unique_effects:
   - name: TheHungerEffect
-    description: >
+    description: >-
       Activate to enter Feast, taking damage over time but gaining significant lifesteal,
       attack speed, and creating aetheric waves with each attack that deal area damage.

--- a/data/weapons/skarn/SkarnsJudgment.yml
+++ b/data/weapons/skarn/SkarnsJudgment.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: DamageChanceStackShield
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to grant a stacking,
       refreshing 40 health shield that lasts for 12s
     value: 40

--- a/data/weapons/skarn/SkarnsMalice.yml
+++ b/data/weapons/skarn/SkarnsMalice.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: DamageChanceStackShield
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to grant a stacking,
       refreshing 40 health shield that lasts for 12s
     value: 40

--- a/data/weapons/skarn/SkarnsRancor.yml
+++ b/data/weapons/skarn/SkarnsRancor.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: DamageChanceStackShield
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to grant a stacking,
       refreshing 40 health shield that lasts for 12s
     value: 40

--- a/data/weapons/skarn/SkarnsSpite.yml
+++ b/data/weapons/skarn/SkarnsSpite.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: DamageChanceStackShield
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to grant a stacking,
       refreshing 40 health shield that lasts for 12s
     value: 40

--- a/data/weapons/skarn/SkarnsVengeance.yml
+++ b/data/weapons/skarn/SkarnsVengeance.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: DamageChanceStackShield
-    description: >
+    description: >-
       Dealing damage has a chance (based on damage dealt) to grant a stacking,
       refreshing 40 health shield that lasts for 12s
     value: 40

--- a/data/weapons/valomyr/ValomyrsBurden.yml
+++ b/data/weapons/valomyr/ValomyrsBurden.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: ValomyrCharge
-    description: >
+    description: >-
       Once charged, your next attack will deal 550 bonus radiant damage.
       Charge rate increases with current health.
     value: 1.5

--- a/data/weapons/valomyr/ValomyrsDecree.yml
+++ b/data/weapons/valomyr/ValomyrsDecree.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: ValomyrCharge
-    description: >
+    description: >-
       Once charged, your next attack will deal 550 bonus radiant damage.
       Charge rate increases with current health.
     value: 1.5

--- a/data/weapons/valomyr/ValomyrsHope.yml
+++ b/data/weapons/valomyr/ValomyrsHope.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: ValomyrCharge
-    description: >
+    description: >-
       Once charged, your next attack will deal 550 bonus radiant damage.
       Charge rate increases with current health.
     value: 1.5

--- a/data/weapons/valomyr/ValomyrsRegard.yml
+++ b/data/weapons/valomyr/ValomyrsRegard.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: ValomyrCharge
-    description: >
+    description: >-
       Once charged, your next attack will deal 550 bonus radiant damage.
       Charge rate increases with current health.
     value: 1.5

--- a/data/weapons/valomyr/ValomyrsRevenge.yml
+++ b/data/weapons/valomyr/ValomyrsRevenge.yml
@@ -37,7 +37,7 @@ perks:
     to: 15
 unique_effects:
   - name: ValomyrCharge
-    description: >
+    description: >-
       Once charged, your next attack will deal 550 bonus radiant damage.
       Charge rate increases with current health.
     value: 1.5


### PR DESCRIPTION
**What I did:**
I added to the multiline yaml strings a block chomping indicator.

**Why I did it:**
Without the block chomping indicator the resulting string would end with an \n

**Fixes issue (include link):**
None

**Mockups, screenshots, evidence:**
before:
`"description": "Dealing damage has a chance (based on damage dealt) to grant a stacking, refreshing 40 health shield that lasts for 12s\n",`
now:
`"description": "Dealing damage has a chance (based on damage dealt) to grant a stacking, refreshing 40 health shield that lasts for 12s",`

**Is this related to an open issue?**
No