### PR TITLE
Fixed the build cards from My Builds screen not having proper dark mode alternatives

### DIFF
--- a/src/styles/_darkmode.scss
+++ b/src/styles/_darkmode.scss
@@ -61,6 +61,44 @@ $theme-input-border: #242424;
         }
     }
 
+    .build-item {
+
+        a:hover {
+            &+.build-actions {
+                background: $theme-item-background-color-hover;
+                color: $theme-font-color;
+            }
+        }
+
+        .build-content {
+            background: $theme-item-background-color;
+
+            .build-title {
+                color: $theme-font-color;
+            }
+
+            &:hover {
+                background: $theme-item-background-color-hover;
+
+                .build-title {
+                    color: $theme-font-color;
+                }
+            }
+        }
+
+        .build-actions {
+            background: $theme-item-background-color;
+
+            .delete-action {
+                cursor: pointer;
+
+                &:hover {
+                    color: $theme-font-color;
+                }
+            }
+        }
+    }
+
     .item:hover {
         background: $theme-item-background-color-hover;
     }

--- a/src/styles/_mybuilds.scss
+++ b/src/styles/_mybuilds.scss
@@ -28,6 +28,13 @@
             background: #EEE;
             padding: 20px;
 
+            transition: background 0.3s ease;
+
+            &:active {
+                background: #AAA;
+                transition-duration: 0.1s;
+            }
+
             &:hover {
                 background: #363636;
 
@@ -63,6 +70,13 @@
 
             height: 100%;
             padding: 20px;
+
+            transition: background 0.3s ease;
+
+            &:active {
+                background: #AAA;
+                transition-duration: 0.1s;
+            }
 
             .delete-action {
                 cursor: pointer;


### PR DESCRIPTION
**What I did:**
Added the SCSS alternatives for dark mode and added transitions for these elements as well

**Why I did it:**
- Out of place white backgrounds during dark mode are a visual annoyance
- The transitions are just a small detail that was missing from this screen

**Fixes issue (include link):**
The build cards from My Builds screen had a white background even when dark mode was enabled 

**Mockups, screenshots, evidence:**
Before 
![bug](https://user-images.githubusercontent.com/6152557/61986091-49c59c80-b015-11e9-97e8-1acd63f41059.gif)

After 
![fix](https://user-images.githubusercontent.com/6152557/61986141-bfca0380-b015-11e9-98ce-36fa12d8dfbf.gif)

**Is this related to an open issue?**
-