### PR TITLE
Fix dropdowns in dark mode so that it stays dark when in focus

### DIFF
--- a/src/styles/_darkmode.scss
+++ b/src/styles/_darkmode.scss
@@ -177,6 +177,10 @@ $theme-input-border: #242424;
             border-color: $theme-input-border;
         }
 
+        .Select.is-focused:not(.is-open) > .Select-control {
+			background-color: $theme-input-background;
+        }
+
         .Select-control {
             background-color: $theme-input-background;
             color: $theme-input-color;

--- a/src/styles/_darkmode.scss
+++ b/src/styles/_darkmode.scss
@@ -178,7 +178,7 @@ $theme-input-border: #242424;
         }
 
         .Select.is-focused:not(.is-open) > .Select-control {
-			background-color: $theme-input-background;
+            background-color: $theme-input-background;
         }
 
         .Select-control {


### PR DESCRIPTION
**What I did:**
Fixed the filter dropdowns so that their background stays dark when in :focus **AND** something is selected.

**Why I did it:**
It would otherwise turn blindingly white whenever you select something.

**Mockups, screenshots, evidence:**
![image](https://user-images.githubusercontent.com/6952853/94353344-298cd580-003e-11eb-912f-a95c62943fb0.png)

**Is this related to an open issue?**
No,