### PR TITLE
Fix: Shrike armour resistance and Twin Suns power

### DIFF
--- a/data/armours/shrike/ShrikedownGloves.yml
+++ b/data/armours/shrike/ShrikedownGloves.yml
@@ -6,7 +6,7 @@ strength: null
 weakness: null
 cells: Mobility
 resistance:
-  0: 20
+  0: 10
   1: 30
 perks:
   - name: Weighted Strikes

--- a/data/armours/shrike/ShrikedownGreaves.yml
+++ b/data/armours/shrike/ShrikedownGreaves.yml
@@ -6,7 +6,7 @@ strength: null
 weakness: null
 cells: Mobility
 resistance:
-  0: 20
+  0: 10
   1: 30
 perks:
   - name: Grace

--- a/data/armours/shrike/ShrikedownHelm.yml
+++ b/data/armours/shrike/ShrikedownHelm.yml
@@ -6,7 +6,7 @@ strength: null
 weakness: null
 cells: Technique
 resistance:
-  0: 20
+  0: 10
   1: 30
 perks:
   - name: Evasion

--- a/data/armours/shrike/ShrikedownPlate.yml
+++ b/data/armours/shrike/ShrikedownPlate.yml
@@ -6,7 +6,7 @@ strength: null
 weakness: null
 cells: Mobility
 resistance:
-  0: 20
+  0: 10
   1: 30
 perks:
   - name: Evasion

--- a/data/weapons/generic/TheTwinSuns.yml
+++ b/data/weapons/generic/TheTwinSuns.yml
@@ -7,7 +7,7 @@ elemental: null
 cells: [Technique, Mobility]
 rarity: exotic
 power:
-  0: 80
+  0: 100
   1: 120
 unique_effects:
   - name: TwinSunsBarrel


### PR DESCRIPTION
I forget this in previous pull resquest --'

### Fix Shrike armours resistance
- Resistance of Shrike's armor before power surging is 10 not 20
![image](https://user-images.githubusercontent.com/16074153/116459371-ff1a2980-a865-11eb-929c-691367e1bdb9.png)

### Fix TwinSuns power
- Power Twin Suns power before power surging is 100 not 80
![image](https://user-images.githubusercontent.com/16074153/116459408-0d684580-a866-11eb-941b-b627201b9885.png)

_Source: [https://playdauntless.com/patch-notes/1-6-1/](https://playdauntless.com/patch-notes/1-6-1/)_ and verifed in game