### PR TITLE
Lanterns and perks fixes

### DIFF
--- a/data/lanterns/BroadsidesLantern.yml
+++ b/data/lanterns/BroadsidesLantern.yml
@@ -4,4 +4,4 @@ description: null
 cells: Utility
 lantern_ability:
   instant: null
-  hold: Hold to drop a bomb from above that explodes after 1 second. Deals 750 damage and can interrupt Behemoths.
+  hold: Drop a bomb from above that explodes after 1 second. Deals 2750 damage and can interrupt Behemoths.

--- a/data/lanterns/DrasksEye.yml
+++ b/data/lanterns/DrasksEye.yml
@@ -4,4 +4,4 @@ description: null
 cells: Utility
 lantern_ability:
   instant: null
-  hold: Fires a lightning bolt in a direction that deals 150 Shock damage multiple times as it passes through enemies.
+  hold: Fires a lightning bolt in a direction that deals 400 Shock damage multiple times as it passes through enemies.

--- a/data/lanterns/EmbermanesRapture.yml
+++ b/data/lanterns/EmbermanesRapture.yml
@@ -4,4 +4,4 @@ description: null
 cells: Utility
 lantern_ability:
   instant: null
-  hold: Create a fire ball in front of you that explodes after 5 seconds, dealing 850 Blaze damage to all nearby Behemoths.
+  hold: Create a fire ball in front of you that explodes after 4 seconds, dealing 3250 Blaze damage to all nearby enemies.

--- a/data/lanterns/KoshaisBloom.yml
+++ b/data/lanterns/KoshaisBloom.yml
@@ -4,4 +4,4 @@ description: null
 cells: Utility
 lantern_ability:
   instant: null
-  hold: Dash in a direction, deal 750 Terra damage to nearby enemies upon arrival.
+  hold: Dash in a direction, deal 2250 Terra damage to nearby enemies upon arrival, and gain 15% lifesteal for 10 seconds.

--- a/data/lanterns/PangarsShine.yml
+++ b/data/lanterns/PangarsShine.yml
@@ -4,4 +4,4 @@ description: null
 cells: Utility
 lantern_ability:
   instant: null
-  hold: Create a frost pillar in front of you that deals 960 Frost damage to nearby enemies over 12 seconds.
+  hold: Create a frost pillar in front of you that deals 2500 Frost damage to nearby enemies over 10 seconds.

--- a/data/lanterns/RecruitsLantern.yml
+++ b/data/lanterns/RecruitsLantern.yml
@@ -4,4 +4,4 @@ description: null
 cells: null
 lantern_ability:
   instant: null
-  hold: Disperses aether that allows the Slayer to track the Behemoth.
+  hold: Grants a 300 hit point shield that lasts 15 seconds.

--- a/data/lanterns/ShrikesZeal.yml
+++ b/data/lanterns/ShrikesZeal.yml
@@ -4,4 +4,4 @@ description: null
 cells: Utility
 lantern_ability:
   instant: null
-  hold: Creates an aura that grants nearby slayers 15% increased move speed and attack speed for 15 seconds.
+  hold: Creates an aura that grants nearby Slayers 15% increased move speed and attack speed for 10 seconds.

--- a/data/lanterns/SkarnsDefiance.yml
+++ b/data/lanterns/SkarnsDefiance.yml
@@ -4,4 +4,4 @@ description: null
 cells: Utility
 lantern_ability:
   instant: null
-  hold: Surrounds the slayer in swirling stone that deals 900 Terra damage to nearby enemies over 10 seconds.
+  hold: Surrounds the slayer in swirling stone that deals 2500 Terra damage to nearby enemies for 10 seconds. Also generates 30 hit point shields per second that expire after 25 seconds. (Max 600 shields)

--- a/data/omnicells/Discipline.yml
+++ b/data/omnicells/Discipline.yml
@@ -2,7 +2,7 @@ name: Discipline
 icon: /assets/icons/omnicells/Discipline.png
 ability_icon: /assets/icons/omnicells/DisciplineAbility.png
 passive: >
-  Critical strike chance and damage increased by 10%. Healing is reduced bz 50%. Reaching max stacks of Flaming Fist
+  Critical strike chance and damage increased by 10%. Healing is reduced by 50%. Reaching max stacks of Flaming Fist
   makes you Disciplined, increasing your critical strike chance by 50% for 40 seconds but increased damage received
   by 100%. When Disciplined ends, stacks are cleared.
 active: >

--- a/data/perks/Engineer.yml
+++ b/data/perks/Engineer.yml
@@ -1,5 +1,5 @@
 name: Engineer
-description: Reduces healing from Slayer flask. Increases range of pylons.
+description: Increases range of pylons.
 type: Utility
 key: IncreasedPylonRange
 effects:

--- a/data/perks/Mender.yml
+++ b/data/perks/Mender.yml
@@ -1,5 +1,5 @@
 name: Mender
-description: Reduces healing from Slayer Flask. Using your flask restores other Slayers' health.
+description: Using your flask restores other Slayers' health.
 type: Utility
 key: HealGroup
 effects:

--- a/data/perks/Sprinter.yml
+++ b/data/perks/Sprinter.yml
@@ -1,5 +1,5 @@
 name: Sprinter
-description: Reduces max stamina. Increases movespeed and reduces sprint cost.
+description: Increases movespeed and reduces sprint cost.
 type: Mobility
 key: Sprinter
 effects:

--- a/data/perks/Strategist.yml
+++ b/data/perks/Strategist.yml
@@ -1,5 +1,5 @@
 name: Strategist
-description: Reduces max health. Dodging through Behemoth attacks grants health shields to all Slayers.
+description: Dodging through Behemoth attacks grants health shields to all Slayers.
 type: Defence
 key: ShieldShare
 effects:

--- a/data/perks/Zeal.yml
+++ b/data/perks/Zeal.yml
@@ -1,23 +1,23 @@
 name: Zeal
-description: Increases Lantern tap ability effectiveness.
+description: Increases Lantern ability effectiveness.
 type: Utility
 key: LanternTapEffectiveness
 effects:
   1:
-    description: +15% Lantern tap ability effectiveness
+    description: +15% Lantern ability effectiveness.
     value: 1.15
   2:
-    description: +25% Lantern tap ability effectiveness
+    description: +25% Lantern ability effectiveness.
     value: 1.25
   3:
-    description: +35% Lantern tap ability effectiveness
+    description: +35% Lantern ability effectiveness.
     value: 1.35
   4:
-    description: +45% Lantern tap ability effectiveness
+    description: +45% Lantern ability effectiveness.
     value: 1.45
   5:
-    description: +55% Lantern tap ability effectiveness
+    description: +55% Lantern ability effectiveness.
     value: 1.55
   6:
-    description: +65% Lantern tap ability effectiveness
+    description: +65% Lantern ability effectiveness.
     value: 1.65


### PR DESCRIPTION
Updated lantern values to 1.7.0.
Fixed perk descriptions (Zeal updated, removed outdated drawbacks from Trials perks' descriptions).
Didn't mess with "LanternTapEffectiveness" key on Zeal, even though it's innacurate, don't know what that might break if I do.😂
Fixed small typo on Discipline's description.